### PR TITLE
fix(export):openapi3 response

### DIFF
--- a/commom/spec/plugin/openapi/3.x.go
+++ b/commom/spec/plugin/openapi/3.x.go
@@ -308,7 +308,7 @@ func (o *OpenAPI) toPaths(ver string, in *spec.Spec) (
 			}
 
 			if len(op.Res.List) == 0 {
-				if in.Common != nil || len(in.Common.Responses) == 0 {
+				if in.Common != nil && len(in.Common.Responses) > 0 {
 					op.Res.List = in.Common.Responses
 				}
 			}


### PR DESCRIPTION
修复导出openapi3时无响应是添加common响应的逻辑bug