### PR TITLE
fix: correct faild->failed typo in config load error message

### DIFF
--- a/app.go
+++ b/app.go
@@ -20,7 +20,7 @@ type App struct{}
 
 func NewApp(conf string) *App {
 	if err := config.Load(conf); err != nil {
-		log.Printf("load config %s faild, use default config. err: %s", conf, err)
+		log.Printf("load config %s failed, use default config. err: %s", conf, err)
 	}
 	config.LoadFromEnv()
 	return &App{}


### PR DESCRIPTION
## Summary
Corrects the `faild->failed` typo in the config load error message (`app.go` line 23).

## Before
```go
log.Printf("load config %s faild, use default config. err: %s", conf, err)
```

## After
```go
log.Printf("load config %s failed, use default config. err: %s", conf, err)
```

## Testing
- Single line change, verified locally

Closes #